### PR TITLE
Adding support for `SimpleMesh` with more coordinates than vertices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Manifest.toml
+.vscode/settings.json

--- a/src/simplemesh.jl
+++ b/src/simplemesh.jl
@@ -21,7 +21,8 @@ function Makie.plot!(plot::Viz{<:Tuple{SimpleMesh}})
   elems = elements(topo)
 
   # coordinates of vertices
-  coords = coordinates.(verts)
+  coords  = coordinates.(verts)
+  ncoords = length(coords)
 
   # fan triangulation (assume convexity)
   tris4elem = map(elems) do elem
@@ -99,7 +100,7 @@ function Makie.plot!(plot::Viz{<:Tuple{SimpleMesh}})
     inds = Int[]
     for i in 1:nfacets(t)
       append!(inds, ∂(i))
-      push!(inds, nvert+1)
+      push!(inds, ncoords+1)
     end
 
     # fill sentinel index with NaN coordinates


### PR DESCRIPTION
The `SimpleMesh` structure is allowed to contain more `coordinates` than `vertices`, i.e. including coordinates not used in the mesh. If this was the case the sentinel node had the wrong index, which resulted in weird facet layouts.